### PR TITLE
Clear temporary arrays for each precompile destinations

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -79,6 +79,7 @@ module.exports = function(grunt) {
         output.unshift(nsInfo.declaration);
         grunt.file.write(files.dest, output.join('\n\n'));
         grunt.log.writeln('File "' + files.dest + '" created.');
+        output.length = partials.length = templates.length = 0;
       }
     });
   });


### PR DESCRIPTION
Output, partials and templates array must be cleared for each precompile destination. Otherwise previous destinations will be copied to next one.
