### PR TITLE
skip namespace with empty namespace string ''

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,14 @@ module.exports = function(grunt) {
         files: {
           'tmp/ns_nested_this.js': ['test/fixtures/basic.hbs']
         }
+      },
+      no_namespace: {
+        options: {
+          namespace: false
+        },
+        files: {
+          'tmp/no_namespace.js': ['test/fixtures/basic.hbs']
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Concatenated files will be joined on this string.
 Type: `String`
 Default: 'JST'
 
-The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces.*
+The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces or false for no namespace wrapping.*
 
 Example:
 ```js

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -10,7 +10,7 @@ Concatenated files will be joined on this string.
 Type: `String`
 Default: 'JST'
 
-The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces.*
+The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces or false for no namespace wrapping.*
 
 Example:
 ```js

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -9,7 +9,6 @@
 'use strict';
 
 module.exports = function(grunt) {
-
   var _ = grunt.util._;
   var helpers = require('grunt-lib-contrib').init(grunt);
 
@@ -31,7 +30,10 @@ module.exports = function(grunt) {
     });
     grunt.verbose.writeflags(options, 'Options');
 
-    var nsInfo = helpers.getNamespaceDeclaration(options.namespace);
+    var nsInfo;
+    if(options.namespace !== false){
+        nsInfo = helpers.getNamespaceDeclaration(options.namespace);
+    }
 
     // assign regex for partial detection
     var isPartial = options.partialRegex || /^_/;
@@ -74,7 +76,11 @@ module.exports = function(grunt) {
           partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
         } else {
           filename = processName(filepath);
-          templates.push(nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+';');
+          if (options.namespace !== false) {
+              templates.push(nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+';');
+          } else {
+              templates.push(compiled);
+          }
         }
       });
 
@@ -82,7 +88,9 @@ module.exports = function(grunt) {
       if (output.length < 1) {
         grunt.log.warn('Destination not written because compiled files were empty.');
       } else {
-        output.unshift(nsInfo.declaration);
+        if (options.namespace !== false) {
+            output.unshift(nsInfo.declaration);
+        }
         grunt.file.write(f.dest, output.join(grunt.util.normalizelf(options.separator)));
         grunt.log.writeln('File "' + f.dest + '" created.');
       }

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -51,4 +51,14 @@ exports.handlebars = {
 
     test.done();
   },
+  no_namespace:function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/no_namespace.js');
+    var expected = grunt.file.read('test/expected/no_namespace.js');
+    test.equal(actual, expected, 'should skip the creation of a namespace array arround the generated template file');
+
+    test.done();
+  }
 };


### PR DESCRIPTION
I required handlebar templates without a wrapped namespace, so i added a check who skips the namespace wrapping if the namespace is an empty string ''.
