### PR TITLE
Fix for AMD

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
           partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
         } else {
           filename = processName(filepath);
-          if (options.namespace !== false && !options.amd) {
+          if (options.namespace !== false) {
             templates.push(nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+';');
           } else {
             templates.push(compiled);
@@ -93,13 +93,14 @@ module.exports = function(grunt) {
       if (output.length < 1) {
         grunt.log.warn('Destination not written because compiled files were empty.');
       } else {
-        if (options.namespace !== false && !options.amd) {
+        if (options.namespace !== false) {
           output.unshift(nsInfo.declaration);
         }
 
         if (options.amd) {
           // Wrap the file in an AMD define fn.
-          output.unshift("define(['handlebars'], function(Handlebars) { return");
+          output.unshift("define(['handlebars'], function(Handlebars) {");
+          output.push("return "+nsInfo.namespace+";");
           output.push("});");
         }
 

--- a/test/expected/amd_compile.js
+++ b/test/expected/amd_compile.js
@@ -1,10 +1,14 @@
-define(['handlebars'], function(Handlebars) { return
+define(['handlebars'], function(Handlebars) {
 
-Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+this["JST"] = this["JST"] || {};
+
+this["JST"]["test/fixtures/amd.html"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   helpers = helpers || Handlebars.helpers; data = data || {};
   
 
 
-  return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";})
+  return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";});
+
+return this["JST"];
 
 });


### PR DESCRIPTION
This fixes the AMD option.

We still require the namespace option enabled for AMD to export the templates back out as the AMD module.

This works for me, tested with a few templates, also added a test for AMD.
