### PR TITLE
Run the partialRegex against the fullpath, not just the filename

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
         }
 
         // register partial or add template to namespace
-        if (isPartial.test(filepath) {
+        if (isPartial.test(filepath)) {
           filename = processPartialName(filepath);
           partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
         } else {


### PR DESCRIPTION
Some people (us) keep partials in a directory, but do not use a prefix. This change might seem sort of radical, but it isn't too much of a burden to create a proper regex. Another option would be to provide a partialsDir option.
