### PR TITLE
0.3.x fix for node option. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-handlebars",
   "description": "Precompile Handlebars templates to JST file.",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "homepage": "https://github.com/gruntjs/grunt-contrib-handlebars",
   "author": {
     "name": "Grunt Team",

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -80,7 +80,8 @@ module.exports = function(grunt) {
         output.unshift(nsInfo.declaration);
 
         if (options.node) {
-          output.unshift('var Handlebars = Handlebars || require(\'Handlebars\');');
+          output.unshift('Handlebars = glob.Handlebars || require(\'handlebars\');');
+          output.unshift('var glob = (\'undefined\' === typeof window) ? global : window,');
 
           var nodeExport = 'if (typeof exports === \'object\' && exports) {';
           nodeExport += 'module.exports = ' + nsInfo.namespace + ';}';

--- a/test/expected/.editorconfig
+++ b/test/expected/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+[*.js]
+
+# Tests have a 2 line space on a line that if removed breaks asserts
+trim_trailing_whitespace = false
+# Same for this rule
+insert_final_newline = false

--- a/test/expected/handlebars-node.js
+++ b/test/expected/handlebars-node.js
@@ -1,4 +1,6 @@
-var Handlebars = Handlebars || require('Handlebars');
+var glob = ('undefined' === typeof window) ? global : window,
+
+Handlebars = glob.Handlebars || require('handlebars');
 
 this["JST"] = this["JST"] || {};
 


### PR DESCRIPTION
Apparently the 'handlebars' npm module is in lower case
