### PR TITLE
Adding a partialsPath option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,6 +152,15 @@ module.exports = function(grunt) {
         files: {
           'tmp/partial_regex.js': ['test/fixtures/par_partial.hbs', 'test/fixtures/one.hbs']
         }
+      },
+      partials_path_regex: {
+        options: {
+          partialRegex: /.*/,
+          partialsPathRegex: /\/partials\//
+        },
+        files: {
+          'tmp/partials_path_regex.js': ['test/fixtures/partials/partial.hbs', 'test/fixtures/one.hbs']
+        }
       }
     },
     // Unit tests.

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -102,3 +102,16 @@ options: {
   partialRegex: /^par_/
 }
 ```
+
+## partialsPathRegex
+Type: `Regexp`
+Default: '/./'
+
+This option accepts a regex that defines the path to a directory of Handlebars partials files. The example below shows how to mark every file in a specific directory as a partial.
+
+``` javascript
+options: {
+  partialRegex: /.*/,
+  partialsPathRegex: /\/partials\//
+}
+```

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -41,6 +41,9 @@ module.exports = function(grunt) {
     if(options.namespace !== false){
       nsInfo = helpers.getNamespaceDeclaration(options.namespace);
     }
+    
+    // assign regex for partials directory detection
+    var partialsPathRegex = options.partialsPathRegex || /./;
 
     // assign regex for partial detection
     var isPartial = options.partialRegex || /^_/;
@@ -84,7 +87,7 @@ module.exports = function(grunt) {
         }
 
         // register partial or add template to namespace
-        if (isPartial.test(_.last(filepath.split('/')))) {
+        if (partialsPathRegex.test(filepath) && isPartial.test(_.last(filepath.split('/')))) {
           filename = processPartialName(filepath);
           partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
         } else {

--- a/test/expected/partials_path_regex.js
+++ b/test/expected/partials_path_regex.js
@@ -1,0 +1,27 @@
+this["JST"] = this["JST"] || {};
+
+Handlebars.registerPartial("partial", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [2,'>= 1.0.0-rc.3'];
+helpers = helpers || Handlebars.helpers; data = data || {};
+  
+
+
+  return "<span>Canada</span>";
+  }));
+
+this["JST"]["test/fixtures/one.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [2,'>= 1.0.0-rc.3'];
+helpers = helpers || Handlebars.helpers; partials = partials || Handlebars.partials; data = data || {};
+  var buffer = "", stack1, functionType="function", escapeExpression=this.escapeExpression, self=this;
+
+
+  buffer += "<p>Hello, my name is ";
+  if (stack1 = helpers.name) { stack1 = stack1.call(depth0, {hash:{},data:data}); }
+  else { stack1 = depth0.name; stack1 = typeof stack1 === functionType ? stack1.apply(depth0) : stack1; }
+  buffer += escapeExpression(stack1)
+    + ". I live in ";
+  stack1 = self.invokePartial(partials.partial, 'partial', depth0, helpers, partials, data);
+  if(stack1 || stack1 === 0) { buffer += stack1; }
+  buffer += "</p>";
+  return buffer;
+  });

--- a/test/fixtures/partials/partial.hbs
+++ b/test/fixtures/partials/partial.hbs
@@ -1,0 +1,1 @@
+<span>Canada</span>

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -140,5 +140,15 @@ exports.handlebars = {
     test.equal(actual, expected, 'should support custom file name identifiers for partials.');
 
     test.done();
+  },
+  partials_path: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/partials_path_regex.js');
+    var expected = grunt.file.read('test/expected/partials_path_regex.js');
+    test.equal(actual, expected, 'should support custom path to partials.');
+
+    test.done();
   }
 };


### PR DESCRIPTION
The default nomenclature for partials – prefixing them with an underscore – works well for small to medium sized projects. But for larger codebases it becomes an issue of practicality to organize types of templates together. For instance, a common pattern is to have a setup like:

```
---templates/
 |--layouts/
 |--partials/
   |--menu.hbs
   |--menu_item.hbs
 |--template_1.hbs
 |--template_2.hbs
 |--etc.
```

This PR adds an option called `partialsPath` which in this example would be set to `templates/partials/`. Used in conjunction with `partialRegex`, an author can configure the task to assume every file in that directory will be a partial.

The default behavior is to leave the path unspecified which allows for partials to live alongside templates.
