### PR TITLE
When a namespace is specified, register partials in that namespace

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,6 +152,14 @@ module.exports = function(grunt) {
         files: {
           'tmp/partial_regex.js': ['test/fixtures/par_partial.hbs', 'test/fixtures/one.hbs']
         }
+      },
+      partials_use_namespace: {
+        options: {
+          partialsUseNamespace: true
+        },
+        files: {
+          'tmp/partials_use_namespace.js': ['test/fixtures/_partial.hbs', 'test/fixtures/one.hbs']
+        }
       }
     },
     // Unit tests.

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -19,6 +19,12 @@ options: {
 }
 ```
 
+## partialsUseNamespace
+Type: `Boolean`
+Default: 'false'
+
+When set to `true`, partials will be registered in the `namespace` in addition to templates.
+
 ## wrapped
 Type: `Boolean`
 Default: `false`

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
     grunt.verbose.writeflags(options, 'Options');
 
     var nsInfo;
-    if(options.namespace !== false){
+    if (options.namespace !== false) {
       nsInfo = helpers.getNamespaceDeclaration(options.namespace);
     }
 
@@ -83,7 +83,11 @@ module.exports = function(grunt) {
         // register partial or add template to namespace
         if (isPartial.test(_.last(filepath.split('/')))) {
           filename = processPartialName(filepath);
-          partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
+          if (options.partialsUseNamespace === true) {
+            partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+');');
+          } else {
+            partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
+          }
         } else {
           filename = processName(filepath);
           if (options.namespace !== false) {

--- a/test/expected/partials_use_namespace.js
+++ b/test/expected/partials_use_namespace.js
@@ -1,0 +1,27 @@
+this["JST"] = this["JST"] || {};
+
+Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [2,'>= 1.0.0-rc.3'];
+helpers = helpers || Handlebars.helpers; data = data || {};
+  
+
+
+  return "<span>Canada</span>";
+  }));
+
+this["JST"]["test/fixtures/one.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [2,'>= 1.0.0-rc.3'];
+helpers = helpers || Handlebars.helpers; partials = partials || Handlebars.partials; data = data || {};
+  var buffer = "", stack1, functionType="function", escapeExpression=this.escapeExpression, self=this;
+
+
+  buffer += "<p>Hello, my name is ";
+  if (stack1 = helpers.name) { stack1 = stack1.call(depth0, {hash:{},data:data}); }
+  else { stack1 = depth0.name; stack1 = typeof stack1 === functionType ? stack1.apply(depth0) : stack1; }
+  buffer += escapeExpression(stack1)
+    + ". I live in ";
+  stack1 = self.invokePartial(partials.partial, 'partial', depth0, helpers, partials, data);
+  if(stack1 || stack1 === 0) { buffer += stack1; }
+  buffer += "</p>";
+  return buffer;
+  });

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -140,5 +140,15 @@ exports.handlebars = {
     test.equal(actual, expected, 'should support custom file name identifiers for partials.');
 
     test.done();
+  },
+  partials_use_namespace: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/partials_use_namespace.js');
+    var expected = grunt.file.read('test/expected/partials_use_namespace.js');
+    test.equal(actual, expected, 'should allow partials to be added to template namespace.');
+
+    test.done();
   }
 };


### PR DESCRIPTION
A namespace is specified for many reasons, most involving the idea of being able to dynamically look up templates at runtime. There are cases where it becomes important to also have access to partials using the same mechanism that’s used for templates.

This PR modifies the `registerPartial()` call to additionally add a reference to the partial in the provided namespace. If no namespace is provided then the `registerPartial()` call is unmodified.
