### PR TITLE
Add processAST option.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,6 +97,21 @@ module.exports = function(grunt) {
           'tmp/processcontent.js': ['test/fixtures/has-spaces.hbs']
         }
       },
+      process_ast: {
+        options: {
+          processAST: function(ast) {
+            ast.statements.forEach(function(statement, i) {
+              if (statement.type === 'partial') {
+                ast.statements[i] = { type: 'content', string: 'Fooville' };
+              }
+            });
+            return ast;
+          }
+        },
+        files: {
+          'tmp/process_ast.js': ['test/fixtures/one.hbs']
+        }
+      },
       amd_compile: {
         options: {
           amd: true

--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ options: {
 }
 ```
 
+#### processAST
+Type: `function`
+
+This option accepts a function which takes one argument (the parsed Abstract Syntax Tree) and returns a modified version which will be used as the source for the precompiled template object.  The example below removes any partial and replaces it with the text `foo`.
+
+```js
+options: {
+  processAST: function(ast) {
+    ast.statements.forEach(function(statement, i) {
+      if (statement.type === 'partial') {
+        ast.statements[i] = { type: 'content', string: 'foo' };
+      }
+    });
+    return ast;
+  }
+}
+```
+
 #### processName
 Type: `function`
 
@@ -190,4 +208,4 @@ handlebars: {
 
 Task submitted by [Tim Branyen](http://tbranyen.com)
 
-*This file was generated on Wed Feb 27 2013 09:38:15.*
+*This file was generated on Wed Mar 06 2013 23:56:18.*

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -67,6 +67,24 @@ options: {
 }
 ```
 
+## processAST
+Type: `function`
+
+This option accepts a function which takes one argument (the parsed Abstract Syntax Tree) and returns a modified version which will be used as the source for the precompiled template object.  The example below removes any partial and replaces it with the text `foo`.
+
+```js
+options: {
+  processAST: function(ast) {
+    ast.statements.forEach(function(statement, i) {
+      if (statement.type === 'partial') {
+        ast.statements[i] = { type: 'content', string: 'foo' };
+      }
+    });
+    return ast;
+  }
+}
+```
+
 ## processName
 Type: `function`
 

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -15,6 +15,9 @@ module.exports = function(grunt) {
   // content conversion for templates
   var defaultProcessContent = function(content) { return content; };
 
+  // AST processing for templates
+  var defaultProcessAST = function(ast) { return ast; };
+
   // filename conversion for templates
   var defaultProcessName = function(name) { return name; };
 
@@ -52,6 +55,7 @@ module.exports = function(grunt) {
     var processContent = options.processContent || defaultProcessContent;
     var processName = options.processName || defaultProcessName;
     var processPartialName = options.processPartialName || defaultProcessPartialName;
+    var processAST = options.processAST || defaultProcessAST;
 
     this.files.forEach(function(f) {
       var partials = [];
@@ -69,9 +73,13 @@ module.exports = function(grunt) {
       })
       .forEach(function(filepath) {
         var src = processContent(grunt.file.read(filepath));
-        var compiled, filename;
+        var Handlebars = require('handlebars');
+        var ast, compiled, filename;
         try {
-          compiled = require('handlebars').precompile(src);
+          // parse the handlebars template into it's AST
+          ast = processAST(Handlebars.parse(src));
+          compiled = Handlebars.precompile(ast);
+
           // if configured to, wrap template in Handlebars.template call
           if (options.wrapped) {
             compiled = 'Handlebars.template('+compiled+')';

--- a/test/expected/process_ast.js
+++ b/test/expected/process_ast.js
@@ -1,0 +1,17 @@
+this["JST"] = this["JST"] || {};
+
+this["JST"]["test/fixtures/one.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [2,'>= 1.0.0-rc.3'];
+helpers = helpers || Handlebars.helpers; data = data || {};
+  var buffer = "", stack1, functionType="function", escapeExpression=this.escapeExpression;
+
+
+  buffer += "<p>Hello, my name is ";
+  if (stack1 = helpers.name) { stack1 = stack1.call(depth0, {hash:{},data:data}); }
+  else { stack1 = depth0.name; stack1 = typeof stack1 === functionType ? stack1.apply(depth0) : stack1; }
+  buffer += escapeExpression(stack1)
+    + ". I live in "
+    + "Fooville"
+    + "</p>";
+  return buffer;
+  });

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -81,6 +81,16 @@ exports.handlebars = {
 
     test.done();
   },
+  process_ast: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/process_ast.js');
+    var expected = grunt.file.read('test/expected/process_ast.js');
+    test.equal(actual, expected, 'should allow the AST to be modified before compilation');
+
+    test.done();
+  },
   amd_compile: function(test) {
     'use strict';
     test.expect(1);


### PR DESCRIPTION
I added an option to modify the abstract syntax tree between parsing and compiling.

I liked Alex Sexton's approach to localization in his require-handlebars-plugin project: https://github.com/SlexAxton/require-handlebars-plugin#i18n but wanted the option to easily do this in my build step.

I'm sure someone could find other reasons to mess with the AST as well :)
