### PR TITLE
Better amd support

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -143,7 +143,7 @@ module.exports = function(grunt) {
         }
 
         if (options.amd) {
-          output = wrapAMD();
+          output = wrapAMD(output);
           if( _.isString(output) ) {
             output = [output];
           }


### PR DESCRIPTION
After considering how to better support partials dependencies on AMD wrapped Handlebars templates, I came up with the solution of adding a new option to the task allowing the user to set a function to customize how the AMD wrapper is added. This way they can parse the compiled output for the dependencies and insert them into the dependencies array of the module definition function using something like this: https://gist.github.com/mleavitt/5327358

This pull request also solves a bug I found where when setting the amd option to true and the namespace option to false partials are passed to the Handlebars.registerPartial function with a return statement prepended which causes a runtime error. I've submitted the issue here: https://github.com/gruntjs/grunt-contrib-handlebars/issues/45
