### PR TITLE
Handlebars version getting out of sync with client JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "handlebars": "~1.0.10",
+    "handlebars": "1.0.11",
     "grunt-lib-contrib": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
We've been running into an issue with the Handlebars dependency being set to "~1.0.10" in package.json. The problem is on our dev machines we've done 'npm install' and got 1.0.10 so everything is working great, however on our build machine (which runs 'npm install' prior to each build) it recently started pulling Handlebars 1.0.11. This causes an error with our precompiled templates as the JS we are including with the client was not updated accordingly. 

Instead of automatically pulling the latest version of Handlebars, which even at patch versions can break the client rendering of precompiled templates, it seems better to be explicit about the version of Handlebars included with this plugin (see the attached pull request).

If there is a better approach, I would love to hear it as this is a big annoyance for us.

Thanks!
