### PR TITLE
Fix Readme processName inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ This option accepts a function which takes one argument (the template filepath) 
 
 ```js
 options: {
-  processName: function(filename) {
-    return filename.toUpperCase();
+  processName: function(filePath) {
+    return filePath.toUpperCase();
   }
 }
 ```


### PR DESCRIPTION
processname function gets a filePath, not the name of the file; bit misleading previously.
