### PR TITLE
Code-ified the default value for partialsUseNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ options: {
 
 #### partialsUseNamespace
 Type: `Boolean`
-Default: 'false'
+Default: `false`
 
 When set to `true`, partials will be registered in the `namespace` in addition to templates.
 


### PR DESCRIPTION
Just changed the value from displaying as a string to displaying as a code boolean.
