### PR TITLE
add support for inlining partials

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,6 +30,17 @@ module.exports = function(grunt) {
 
     // Configuration to be run (and then tested).
     handlebars: {
+      inline_partials: {
+        options: {
+          namespace: 'JST',
+          partialRegex: /.*/,
+          partialsPathRegex: /\/partials\//,
+          partialsInline: true
+        },
+        files: {
+          'tmp/inline_partials.js': ['test/fixtures/partials/inlined.hbs', 'test/fixtures/inline_partials.hbs']
+        }
+      },
       compile: {
         options: {
           namespace: 'JST'

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -15,6 +15,22 @@ module.exports = function(grunt) {
   // content conversion for templates
   var defaultProcessContent = function(content) { return content; };
 
+  var processASTPartialsInline = function(ast) {
+    var Handlebars = require('handlebars');
+    ast.statements.forEach(function(statement, i) {
+      if (statement.type === 'partial') {
+        var partialFile = grunt.util._.find(grunt.task.current.files, function (file) {
+            return file.src[0].indexOf(statement.partialName.name) !== -1;
+        });
+        if (partialFile) {
+            var parsed = Handlebars.parse(grunt.file.read(partialFile.src[0]));
+            ast.statements.splice.apply(ast.statements, [i, 1].concat(parsed.statements));
+        }
+      }
+    });
+    return ast;
+  };
+
   // AST processing for templates
   var defaultProcessAST = function(ast) { return ast; };
 
@@ -84,6 +100,9 @@ module.exports = function(grunt) {
         try {
           // parse the handlebars template into it's AST
           ast = processAST(Handlebars.parse(src));
+          if (options.partialsInline) {
+            ast = processASTPartialsInline(ast);
+          }
           compiled = Handlebars.precompile(ast, compilerOptions);
 
           // if configured to, wrap template in Handlebars.template call
@@ -97,11 +116,13 @@ module.exports = function(grunt) {
 
         // register partial or add template to namespace
         if (partialsPathRegex.test(filepath) && isPartial.test(_.last(filepath.split('/')))) {
-          filename = processPartialName(filepath);
-          if (options.partialsUseNamespace === true) {
-            partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+');');
-          } else {
-            partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
+          if (! options.partialsInline) {
+            filename = processPartialName(filepath);
+            if (options.partialsUseNamespace === true) {
+              partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+');');
+            } else {
+              partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
+            }
           }
         } else {
           if(options.amd && options.namespace === false) {

--- a/test/expected/inline_partials.js
+++ b/test/expected/inline_partials.js
@@ -1,0 +1,15 @@
+this["JST"] = this["JST"] || {};
+
+this["JST"]["test/fixtures/inline_partials.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+  var buffer = "";
+
+
+  buffer += "<div>"
+    + "<span>Inlined</span>"
+    + "</div>\n<div>"
+    + "<span>Inlined</span>"
+    + "</div>";
+  return buffer;
+  });

--- a/test/fixtures/inline_partials.hbs
+++ b/test/fixtures/inline_partials.hbs
@@ -1,0 +1,2 @@
+<div>{{> inlined}}</div>
+<div>{{> inlined}}</div>

--- a/test/fixtures/partials/inlined.hbs
+++ b/test/fixtures/partials/inlined.hbs
@@ -1,0 +1,1 @@
+<span>Inlined</span>

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -27,6 +27,20 @@ function filesAreEqual(actual, expected, fn) {
 }
 
 exports.handlebars = {
+  inlined_partials: function(test) {
+    test.expect(2);
+
+    testhbs('inline_partials.js', function(tpl) {
+      var actual = tpl();
+      var expected = '<div><span>Inlined</span></div>\n<div><span>Inlined</span></div>';
+      test.equal(actual, expected, 'should compile partials into Handlebars.partials and handlebars template into JST');
+
+      filesAreEqual('inline_partials.js', function(actual, expected) {
+        test.equal(actual, expected, 'should compile partials into Handlebars.partials and handlebars template into JST');
+        test.done();
+      });
+    });
+  },
   compile: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
This allows optional (and opt-in) inlining of partials. It injects the parsed AST of partials in place of the traditional `partial` nodes, which cause `registerPartial` calls in the compiled templates. The rational is that this is sometimes more convenient in contexts such as AMD and Require.js, when you are compiling each template independently, and it can become tedious to ensure you require all partial dependencies of a template whenever you require the template itself in a module.

Feedback and suggestions are welcome. There is nothing special about this implementation, I'm just throwing the idea out there.
