### PR TITLE
Added amdRequire option to specify AMD dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,6 +120,15 @@ module.exports = function(grunt) {
           'tmp/amd_compile.js': ['test/fixtures/amd.html']
         }
       },
+      amd_compile_deps: {
+        options: {
+          amd: true,
+          amdRequire: ['handlebars.helpers']
+        },
+        files: {
+          'tmp/amd_compile_deps.js': ['test/fixtures/amd.html']
+        }
+      },
       amd_compile_direct: {
         options: {
           amd: true,

--- a/README.md
+++ b/README.md
@@ -81,6 +81,34 @@ define(function() {
 });
 ```
 
+#### amdRequire
+Type: `String[]`  
+Default: `['handlebars']`
+
+If `amd` is true, `amdRequire` contains the list of dependencies when the module is `define()`d.
+
+This can be used if you have a separate AMD module that defines your Handlebars helpers that you need loaded prior to compiling your templates.
+
+```js
+// handlebars.helpers.js
+define("handlebars.helpers", ["handlebars"], function(Handlebars) {
+    Handlebars.registerHelper('foo', function(context, options) {
+        ...
+    )};
+});
+
+// Gruntfile.js
+handlebars: {
+    compile: {
+        options: {
+            amd: true,
+            amdRequire: ['handlebars', 'handlebars.helpers']
+        }
+        ...
+    }
+}
+```
+
 #### commonjs
 Type: `Boolean`  
 Default: `false`
@@ -253,4 +281,4 @@ handlebars: {
 
 Task submitted by [Tim Branyen](http://tbranyen.com)
 
-*This file was generated on Tue Oct 01 2013 08:22:08.*
+*This file was generated on Sun Nov 03 2013 21:22:36.*

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -52,6 +52,34 @@ define(function() {
 });
 ```
 
+## amdRequire
+Type: `String[]`  
+Default: `['handlebars']`
+
+If `amd` is true, `amdRequire` contains the list of dependencies when the module is `define()`d.
+
+This can be used if you have a separate AMD module that defines your Handlebars helpers that you need loaded prior to compiling your templates.
+
+```js
+// handlebars.helpers.js
+define("handlebars.helpers", ["handlebars"], function(Handlebars) {
+    Handlebars.registerHelper('foo', function(context, options) {
+        ...
+    )};
+});
+
+// Gruntfile.js
+handlebars: {
+    compile: {
+        options: {
+            amd: true,
+            amdRequire: ['handlebars', 'handlebars.helpers']
+        }
+        ...
+    }
+}
+```
+
 ## commonjs
 Type: `Boolean`  
 Default: `false`

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
       separator: grunt.util.linefeed + grunt.util.linefeed,
       wrapped: true,
       amd: false,
+      amdRequire: ['handlebars'],
       commonjs: false,
       knownHelpers: [],
       knownHelpersOnly: false
@@ -138,8 +139,35 @@ module.exports = function(grunt) {
         }
 
         if (options.amd) {
+          // ensure 'handlebars' is the first dependency
+          if (options.amdRequire.length > 0) {
+            var amdHandlebarsIdx = options.amdRequire.indexOf('handlebars');
+            if (amdHandlebarsIdx === -1 || amdHandlebarsIdx > 0) {
+              if (amdHandlebarsIdx > 0) {
+                // 'handlebars' needs to be first, so remove it from the array
+                options.amdRequire.splice(amdHandlebarsIdx, 1);
+              }
+
+              // add to the beginning of the array
+              options.amdRequire.unshift('handlebars');
+            }
+          } else {
+            // no dependencies specified, ensure 'handlebars' is the only one
+            options.amdRequire = ['handlebars'];
+          }
+
+          // convert options.amdRequire to a string of dependencies for require([...])
+          var amdRequireString = '';
+          for (var i = 0; i < options.amdRequire.length; i++) {
+            if (i !== 0) {
+              amdRequireString += ', ';
+            }
+
+            amdRequireString += "'" + options.amdRequire[i] + "'";
+          }
+
           // Wrap the file in an AMD define fn.
-          output.unshift("define(['handlebars'], function(Handlebars) {");
+          output.unshift("define([" + amdRequireString + "], function(Handlebars) {");
           if (options.namespace !== false) {
             // Namespace has not been explicitly set to false; the AMD
             // wrapper will return the object containing the template.

--- a/test/expected/amd_compile_deps.js
+++ b/test/expected/amd_compile_deps.js
@@ -1,0 +1,16 @@
+define(['handlebars','handlebars.helpers'], function(Handlebars) {
+
+this["JST"] = this["JST"] || {};
+
+this["JST"]["test/fixtures/amd.html"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+
+
+
+  return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
+  });
+
+return this["JST"];
+
+});

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -119,6 +119,14 @@ exports.handlebars = {
       test.done();
     });
   },
+  amd_compile_deps: function(test) {
+    test.expect(1);
+
+    filesAreEqual('amd_compile_deps.js', function(actual, expected) {
+      test.equal(actual, expected, 'should wrap everything with an AMD define block with the right dependencies.');
+      test.done();
+    });
+  },
   amd_compile_direct: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
I've added a new option `amdRequire` to help when your Handlebars helpers are defined in a separate module that needs to be loaded prior to compiling your templates.

This option will help with this issue:
https://github.com/gruntjs/grunt-contrib-handlebars/issues/58

Simply put, instead of always generating this AMD header:

``` js
define(['handlebars'], function(Handlebars) {
```

When you specify `amdRequire`:

``` js
options: {
   ...
   amd: true,
   amdRequire: ['handlebars.helpers']
}
```

Then the output will be this:

``` js
define(['handlebars','handlebars.helpers'], function(Handlebars) {
```
