### PR TITLE
Adds ability to support RequireJS pragmas plus tests and windows tests support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,6 +119,15 @@ module.exports = function(grunt) {
         files: {
           'tmp/amd_compile.js': ['test/fixtures/amd.html']
         }
+      }, 
+      amd_compile_pragmas: {
+        options: {
+          amd: true,
+          includePragmas: 'myPragmaBuildExclude'
+        },
+        files: {
+          'tmp/amd_compile_pragmas.js': ['test/fixtures/amd.html']
+        }
       },
       amd_compile_direct: {
         options: {

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -138,14 +138,33 @@ module.exports = function(grunt) {
         }
 
         if (options.amd) {
+          // Wrap with user defined pragmas
+          if( options.includePragmas ) {
+            output.unshift( '\n //>>excludeEnd("' + options.includePragmas + '");\n (function(){' );
+          }
+
           // Wrap the file in an AMD define fn.
           output.unshift("define(['handlebars'], function(Handlebars) {");
+
+          if( options.includePragmas ) {
+            output.unshift( '//>>excludeStart("' + options.includePragmas + '", pragmas.' + options.includePragmas + ');\n' );
+          }
           if (options.namespace !== false) {
             // Namespace has not been explicitly set to false; the AMD
             // wrapper will return the object containing the template.
             output.push("return "+nsInfo.namespace+";");
           }
+
+          // wrap in pragmas
+          if( options.includePragmas ) {
+            output.push( '})();\n//>>excludeStart("' + options.includePragmas + '", pragmas.' + options.includePragmas + ');\n' );
+          }
           output.push("});");
+
+          // Wrap with user defined pragmas
+          if( options.includePragmas ) {
+            output.push( '\n //>>excludeEnd("' + options.includePragmas + '");' );
+          }
         }
 
         if (options.commonjs) {

--- a/test/expected/amd_compile_pragmas.js
+++ b/test/expected/amd_compile_pragmas.js
@@ -1,0 +1,30 @@
+//>>excludeStart("myPragmaBuildExclude", pragmas.myPragmaBuildExclude);
+
+
+define(['handlebars'], function(Handlebars) {
+
+
+ //>>excludeEnd("myPragmaBuildExclude");
+ (function(){
+
+this["JST"] = this["JST"] || {};
+
+this["JST"]["test/fixtures/amd.html"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+  
+
+
+  return "<section class=\"main-app\">\r\n    <h1>Some title</h1>\r\n    <p>I've been compiled with amd support</p>\r\n</section>";
+  });
+
+return this["JST"];
+
+})();
+//>>excludeStart("myPragmaBuildExclude", pragmas.myPragmaBuildExclude);
+
+
+});
+
+
+ //>>excludeEnd("myPragmaBuildExclude");

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -20,9 +20,13 @@ function filesAreEqual(actual, expected, fn) {
     fn = expected;
     expected = actual;
   }
+  var regex = new RegExp('\\s','g');
+  if(!!process.platform.match(/^win/)) {
+    regex = new RegExp('(\\s)|(\\\\r)', 'g');
+  }
   fn(
-    String(grunt.file.read(path.join('tmp', actual))).replace(/\s/g, ''),
-    String(grunt.file.read(path.join('test', 'expected', expected))).replace(/\s/g, '')
+    String(grunt.file.read(path.join('tmp', actual))).replace(regex, ''),
+    String(grunt.file.read(path.join('test', 'expected', expected))).replace(regex, '')
   );
 }
 
@@ -116,6 +120,14 @@ exports.handlebars = {
 
     filesAreEqual('amd_compile.js', function(actual, expected) {
       test.equal(actual, expected, 'should wrap everything with an AMD define block.');
+      test.done();
+    });
+  },
+  amd_compile_pragmas: function(test) {
+    test.expect(1);
+
+    filesAreEqual('amd_compile_pragmas.js', function(actual, expected) {
+      test.equal(actual, expected, 'should wrap everything with an AMD define block with pragmas.');
       test.done();
     });
   },


### PR DESCRIPTION
We have a large jQuery Mobile project and use pragmas in the same fashion that the jQuery Mobile team uses them.  This PR is for a small change to support the ability to include pragmas.

I also included a small change in the test file to support windows/different line endings.  It shouldn't break it for you guys since it checks for windows and only applys the different regex then.  When I originally ran the test after doing a fresh fork they all failed and it was because \r\n !== \n.

I just realized that I forgot to include some updates to the documentation to explain how to use it but I'll submit that as a different PR if there are no issues with this one.
