### PR TITLE
Directly return template without namespace with commonjs

### DIFF
--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -10,7 +10,7 @@ Concatenated files will be joined on this string.
 Type: `String` `false`  
 Default: `'JST'`
 
-The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces or false for no namespace wrapping.*  When false with `amd` option set `true`, templates will be returned directly from the AMD wrapper.
+The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces or false for no namespace wrapping.*  When false with `amd` or `commonjs` option set `true`, templates will be returned directly from the AMD/CommonJS wrapper.
 
 Example:
 ```js

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -103,7 +103,7 @@ module.exports = function(grunt) {
             partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+compiled+');');
           }
         } else {
-          if(options.amd && options.namespace === false) {
+          if (options.namespace === false && (options.amd || options.commonjs)) {
             compiled = 'return ' + compiled;
           }
           filename = processName(filepath);
@@ -148,10 +148,7 @@ module.exports = function(grunt) {
         }
 
         if (options.commonjs) {
-          if (options.namespace === false) {
-            output.unshift('var templates = {};');
-            output.push("return templates;");
-          } else {
+          if (options.namespace) {
             output.push("return "+nsInfo.namespace+";");
           }
           // Export the templates object for CommonJS environments.

--- a/test/expected/commonjs_compile_direct.js
+++ b/test/expected/commonjs_compile_direct.js
@@ -1,16 +1,12 @@
 module.exports = function(Handlebars) {
 
-var templates = {};
-
-templates["test/fixtures/commonjs.html"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+templates["test/fixtures/commonjs.html"] = return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
+
 
 
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with CommonJS support</p>\n</section>\n";
   });
-
-return templates;
 
 };


### PR DESCRIPTION
When commonjs set to true and namespace set to false directly return template without namespace.