### PR TITLE
Colorize created path as cyan (using chalk)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {
     "handlebars": "~1.1.2",
-    "grunt-lib-contrib": "~0.5.1"
+    "grunt-lib-contrib": "~0.5.1",
+    "chalk": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -7,6 +7,7 @@
  */
 
 'use strict';
+var chalk = require('chalk');
 
 module.exports = function(grunt) {
   var _ = grunt.util._;
@@ -160,7 +161,7 @@ module.exports = function(grunt) {
         }
 
         grunt.file.write(f.dest, output.join(grunt.util.normalizelf(options.separator)));
-        grunt.log.writeln('File "' + f.dest + '" created.');
+        grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
       }
     });
 


### PR DESCRIPTION
- Add [chalk](https://github.com/sindresorhus/chalk) as a dependency.
- Output the name of the files that have been created colorized in cyan and without quotes, which is arguably more readable.

The format will become unified with `grunt-contrib-less` and `grunt-contrib-coffee` (see https://github.com/gruntjs/grunt-contrib-coffee/pull/79), and hopefully with `grunt-contrib-sass` (https://github.com/gruntjs/grunt-contrib-sass/pull/81).
