### PR TITLE
the grunt.log calls can be very abundant...

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -175,7 +175,7 @@ module.exports = function(grunt) {
         }
 
         grunt.file.write(f.dest, output.join(grunt.util.normalizelf(options.separator)));
-        grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
+        grunt.verbose.writeln('File ' + chalk.cyan(f.dest) + ' created.');
       }
     });
 


### PR DESCRIPTION
the grunt.log call at the end of the file potentially creates very abundant logs and obfuscate important messages when dealing with a large number of files IMHO.
I would suggest to replace this 1 reference with grunt.verbose
