### PR TITLE
updated grunt logs to be less verbose

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -66,7 +66,8 @@ module.exports = function(grunt) {
     });
 
     // assign compiler options
-    var compilerOptions = options.compilerOptions || {};
+    var compilerOptions = options.compilerOptions || {},
+        filesCount = 0;
 
     this.files.forEach(function(f) {
       var partials = [];
@@ -179,10 +180,13 @@ module.exports = function(grunt) {
           output.push("};");
         }
 
+        filesCount++;
         grunt.file.write(f.dest, output.join(grunt.util.normalizelf(options.separator)));
-        grunt.log.writeln('File ' + chalk.cyan(f.dest) + ' created.');
+        grunt.verbose.writeln('File ' + chalk.cyan(f.dest) + ' created.');
       }
     });
+
+    grunt.log.ok(filesCount + ' ' + grunt.util.pluralize(filesCount,'file/files') + ' created.');
 
   });
 


### PR DESCRIPTION
As discussed in pull/101, I'm resubmitting the change to decrease the verbosity when compile templates.
- Default mode:

```
Running "handlebars:compile" (handlebars) task
>> 122 files created.
```
- Verbose mode:

```
File template1.js created.
File template2.js created.
File template3.js created.
...
>> 122 files created.
```
