### PR TITLE
Handlebars as option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -273,6 +273,17 @@ module.exports = function(grunt) {
         files: {
           'tmp/namespace_as_function.js' : [ 'test/fixtures/modules/**/*.hbs']
         }
+      },
+      custom_version: {
+        options: {
+          handlebars: {
+            parse: function() {},
+            precompile: function() {}
+          }
+        },
+        files: {
+          'tmp/custom_version.js' : [ 'test/fixtures/modules/**/*.hbs']
+        }
       }
     },
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,29 @@ options: {
 }
 ```
 
+#### handlebars
+Type: `Object`
+
+Default: `handlebars@~1.3.0`
+
+Pass a reference to Handlebars to override the default version. Use this to pin the Handlebars compiler to the same version as your application. This example shows how you can specify a Handlebars dependency version in your `package.json` and pass it as an option in the `Gruntfile.js`.
+
+package.json:
+```js
+...
+dependencies: {
+  'handlebars': '2.0.0'
+}
+...
+```
+
+Gruntfile.js:
+```js
+options: {
+  handlebars: require('handlebars')
+}
+```
+
 ### Usage Examples
 
 ```js

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -40,7 +40,8 @@ module.exports = function(grunt) {
       amd: false,
       commonjs: false,
       knownHelpers: [],
-      knownHelpersOnly: false
+      knownHelpersOnly: false,
+      handlebars: null
     });
 
     // assign regex for partials directory detection
@@ -96,7 +97,7 @@ module.exports = function(grunt) {
       .forEach(function(filepath) {
         var src = processContent(grunt.file.read(filepath), filepath);
 
-        var Handlebars = require('handlebars');
+        var Handlebars = options.handlebars || require('handlebars');
         var ast, compiled, filename;
         try {
           // parse the handlebars template into it's AST

--- a/test/expected/custom_version.js
+++ b/test/expected/custom_version.js
@@ -1,0 +1,7 @@
+this["JST"] = this["JST"] || {};
+
+this["JST"]["test/fixtures/modules/countries/basic.hbs"] = Handlebars.template(undefined);
+
+
+
+this["JST"]["test/fixtures/modules/treeNav/leaves/basic.hbs"] = Handlebars.template(undefined);

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -250,6 +250,14 @@ exports.handlebars = {
       test.equal(actual, expected, 'namespace should allow function to allow nested namespaces based on file system structure.');
       test.done();
     });
+  },
+  custom_version: function(test) {
+    test.expect(1);
+
+    filesAreEqual('custom_version.js', function(actual, expected) {
+      test.equal(actual, expected, 'sould support any version of Handlebars');
+      test.done();
+    });
   }
 
 };


### PR DESCRIPTION
This should provide a solution to #100 with full backwards and forwards compatibility.

Thanks to @lazd for the suggestion and his implementation in lazd/gulp-handlebars#29.

For the test I've mocked out Handlebars. Seems to work. But it would also be nice to test with actual releases of Handlebars. That's probably stuck on npm/npm#5499 though.
