### PR TITLE
Update compiler to use handlebars 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "chalk": "~0.4.0",
-    "handlebars": "2.0.0",
+    "handlebars": "^2.0.0",
     "nsdeclare": "0.1.0"
   },
   "devDependencies": {

--- a/test/expected/amd_compile.js
+++ b/test/expected/amd_compile.js
@@ -2,14 +2,9 @@ define(['handlebars'], function(Handlebars) {
 
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/amd.html"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+this["JST"]["test/fixtures/amd.html"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
-  });
+  },"useData":true});
 
 return this["JST"];
 

--- a/test/expected/amd_compile_array.js
+++ b/test/expected/amd_compile_array.js
@@ -1,12 +1,7 @@
 define(['handlebars', 'handlebars.helpers'], function(Handlebars) {
 
-return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+return Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
-  })
+  },"useData":true})
 
 });

--- a/test/expected/amd_compile_direct.js
+++ b/test/expected/amd_compile_direct.js
@@ -1,12 +1,7 @@
 define(['handlebars'], function(Handlebars) {
 
-return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+return Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
-  })
+  },"useData":true})
 
 });

--- a/test/expected/amd_compile_string_deps.js
+++ b/test/expected/amd_compile_string_deps.js
@@ -1,12 +1,7 @@
 define(['handlebars', 'handlebars.helpers'], function(Handlebars) {
 
-return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+return Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
-  })
+  },"useData":true})
 
 });

--- a/test/expected/amd_compile_string_path.js
+++ b/test/expected/amd_compile_string_path.js
@@ -1,12 +1,7 @@
 define(['lib/handlebars'], function(Handlebars) {
 
-return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+return Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
-  })
+  },"useData":true})
 
 });

--- a/test/expected/commonjs_compile.js
+++ b/test/expected/commonjs_compile.js
@@ -2,14 +2,9 @@ module.exports = function(Handlebars) {
 
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/commonjs.html"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+this["JST"]["test/fixtures/commonjs.html"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with CommonJS support</p>\n</section>\n";
-  });
+  },"useData":true});
 
 return this["JST"];
 

--- a/test/expected/commonjs_compile_direct.js
+++ b/test/expected/commonjs_compile_direct.js
@@ -2,14 +2,9 @@ module.exports = function(Handlebars) {
 
 var templates = {};
 
-templates["test/fixtures/commonjs.html"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+templates["test/fixtures/commonjs.html"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with CommonJS support</p>\n</section>\n";
-  });
+  },"useData":true});
 
 return templates;
 

--- a/test/expected/custom_separator.js
+++ b/test/expected/custom_separator.js
@@ -1,8 +1,3 @@
-this["JST"] = this["JST"] || {};;;;;;this["JST"]["test/fixtures/basic.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+this["JST"] = this["JST"] || {};;;;;;this["JST"]["test/fixtures/basic.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "Basic template that does nothing.";
-  });
+  },"useData":true});

--- a/test/expected/handlebarsnowrap.js
+++ b/test/expected/handlebarsnowrap.js
@@ -1,27 +1,14 @@
-Handlebars.registerPartial("partial", function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+Handlebars.registerPartial("partial", {"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<span>Canada</span>";
-  });
+  },"useData":true});
 
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/one.hbs"] = function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
-  var buffer = "", stack1, helper, functionType="function", escapeExpression=this.escapeExpression, self=this;
-
-
-  buffer += "<p>Hello, my name is ";
-  if (helper = helpers.name) { stack1 = helper.call(depth0, {hash:{},data:data}); }
-  else { helper = (depth0 && depth0.name); stack1 = typeof helper === functionType ? helper.call(depth0, {hash:{},data:data}) : helper; }
-  buffer += escapeExpression(stack1)
+this["JST"]["test/fixtures/one.hbs"] = {"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
+    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in ";
-  stack1 = self.invokePartial(partials.partial, 'partial', depth0, helpers, partials, data);
-  if(stack1 || stack1 === 0) { buffer += stack1; }
-  buffer += "</p>";
-  return buffer;
-  };
+  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</p>";
+},"usePartial":true,"useData":true};

--- a/test/expected/known_helpers.js
+++ b/test/expected/known_helpers.js
@@ -1,24 +1,13 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  var buffer = "", stack1, helper, options, escapeExpression=this.escapeExpression, self=this, functionType="function", blockHelperMissing=helpers.blockHelperMissing;
-
-function program1(depth0,data) {
-  
-  var buffer = "";
-  return buffer;
-  }
-
-  buffer += "This template uses custom helpers: "
-    + escapeExpression(helpers['my-helper'].call(depth0, "variable", {hash:{},data:data}))
+this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(depth0,helpers,partials,data) {
+  return "";
+},"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, helper, options, escapeExpression=this.escapeExpression, functionType="function", helperMissing=helpers.helperMissing, blockHelperMissing=helpers.blockHelperMissing, buffer = "This template uses custom helpers: "
+    + escapeExpression(helpers['my-helper'].call(depth0, "variable", {"name":"my-helper","hash":{},"data":data}))
     + " & ";
-  options={hash:{},inverse:self.noop,fn:self.program(1, program1, data),data:data}
-  if (helper = helpers['another-helper']) { stack1 = helper.call(depth0, options); }
-  else { helper = (depth0 && depth0['another-helper']); stack1 = typeof helper === functionType ? helper.call(depth0, options) : helper; }
-  if (!helpers['another-helper']) { stack1 = blockHelperMissing.call(depth0, stack1, {hash:{},inverse:self.noop,fn:self.program(1, program1, data),data:data}); }
-  if(stack1 || stack1 === 0) { buffer += stack1; }
-  buffer += "!\n";
-  return buffer;
-  });
+  stack1 = ((helper = (helper = helpers['another-helper'] || (depth0 != null ? depth0['another-helper'] : depth0)) != null ? helper : helperMissing),(options={"name":"another-helper","hash":{},"fn":this.program(1, data),"inverse":this.noop,"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
+  if (!helpers['another-helper']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "!\n";
+},"useData":true});

--- a/test/expected/namespace_as_function.js
+++ b/test/expected/namespace_as_function.js
@@ -1,23 +1,13 @@
 this["JST"] = this["JST"] || {};
 this["JST"]["countries"] = this["JST"]["countries"] || {};
 
-this["JST"]["countries"]["basic"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+this["JST"]["countries"]["basic"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "Basic template that does nothing.";
-  });
+  },"useData":true});
 
 this["JST"]["treeNav"] = this["JST"]["treeNav"] || {};
 this["JST"]["treeNav"]["leaves"] = this["JST"]["treeNav"]["leaves"] || {};
 
-this["JST"]["treeNav"]["leaves"]["basic"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+this["JST"]["treeNav"]["leaves"]["basic"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "Basic template that does nothing.";
-  });
+  },"useData":true});

--- a/test/expected/no_namespace.js
+++ b/test/expected/no_namespace.js
@@ -1,8 +1,3 @@
-Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "Basic template that does nothing.";
-  })
+  },"useData":true})

--- a/test/expected/ns_nested.js
+++ b/test/expected/ns_nested.js
@@ -2,11 +2,6 @@ this["MyApp"] = this["MyApp"] || {};
 this["MyApp"]["JST"] = this["MyApp"]["JST"] || {};
 this["MyApp"]["JST"]["Main"] = this["MyApp"]["JST"]["Main"] || {};
 
-this["MyApp"]["JST"]["Main"]["test/fixtures/basic.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+this["MyApp"]["JST"]["Main"]["test/fixtures/basic.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "Basic template that does nothing.";
-  });
+  },"useData":true});

--- a/test/expected/only_known_helpers.js
+++ b/test/expected/only_known_helpers.js
@@ -1,21 +1,12 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  var buffer = "", stack1, escapeExpression=this.escapeExpression, self=this;
-
-function program1(depth0,data) {
-  
-  var buffer = "";
-  return buffer;
-  }
-
-  buffer += "This template uses custom helpers: "
-    + escapeExpression(helpers['my-helper'].call(depth0, "variable", {hash:{},data:data}))
+this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(depth0,helpers,partials,data) {
+  return "";
+},"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, escapeExpression=this.escapeExpression, buffer = "This template uses custom helpers: "
+    + escapeExpression(helpers['my-helper'].call(depth0, "variable", {"name":"my-helper","hash":{},"data":data}))
     + " & ";
-  stack1 = helpers['another-helper'].call(depth0, {hash:{},inverse:self.noop,fn:self.program(1, program1, data),data:data});
-  if(stack1 || stack1 === 0) { buffer += stack1; }
-  buffer += "!\n";
-  return buffer;
-  });
+  stack1 = helpers['another-helper'].call(depth0, {"name":"another-helper","hash":{},"fn":this.program(1, data),"inverse":this.noop,"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "!\n";
+},"useData":true});

--- a/test/expected/partials_path_regex.js
+++ b/test/expected/partials_path_regex.js
@@ -1,27 +1,14 @@
-Handlebars.registerPartial("partial", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+Handlebars.registerPartial("partial", Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<span>Canada</span>";
-  }));
+  },"useData":true}));
 
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/one.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
-  var buffer = "", stack1, helper, functionType="function", escapeExpression=this.escapeExpression, self=this;
-
-
-  buffer += "<p>Hello, my name is ";
-  if (helper = helpers.name) { stack1 = helper.call(depth0, {hash:{},data:data}); }
-  else { helper = (depth0 && depth0.name); stack1 = typeof helper === functionType ? helper.call(depth0, {hash:{},data:data}) : helper; }
-  buffer += escapeExpression(stack1)
+this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
+    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in ";
-  stack1 = self.invokePartial(partials.partial, 'partial', depth0, helpers, partials, data);
-  if(stack1 || stack1 === 0) { buffer += stack1; }
-  buffer += "</p>";
-  return buffer;
-  });
+  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</p>";
+},"usePartial":true,"useData":true});

--- a/test/expected/partials_use_namespace.js
+++ b/test/expected/partials_use_namespace.js
@@ -1,27 +1,16 @@
 this["JST"] = this["JST"] || {};
 
-Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<span>Canada</span>";
-  }));
-
-this["JST"]["test/fixtures/one.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
-  var buffer = "", stack1, helper, functionType="function", escapeExpression=this.escapeExpression, self=this;
+  },"useData":true}));
 
 
-  buffer += "<p>Hello, my name is ";
-  if (helper = helpers.name) { stack1 = helper.call(depth0, {hash:{},data:data}); }
-  else { helper = (depth0 && depth0.name); stack1 = typeof helper === functionType ? helper.call(depth0, {hash:{},data:data}) : helper; }
-  buffer += escapeExpression(stack1)
+
+this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
+    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in ";
-  stack1 = self.invokePartial(partials.partial, 'partial', depth0, helpers, partials, data);
-  if(stack1 || stack1 === 0) { buffer += stack1; }
-  buffer += "</p>";
-  return buffer;
-  });
+  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</p>";
+},"usePartial":true,"useData":true});

--- a/test/expected/processname.js
+++ b/test/expected/processname.js
@@ -1,10 +1,5 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["TEST/FIXTURES/BASIC.HBS"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  
-
-
+this["JST"]["TEST/FIXTURES/BASIC.HBS"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "Basic template that does nothing.";
-  });
+  },"useData":true});

--- a/test/expected/unknown_helpers.js
+++ b/test/expected/unknown_helpers.js
@@ -1,24 +1,13 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  var buffer = "", stack1, helper, options, helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, self=this, functionType="function", blockHelperMissing=helpers.blockHelperMissing;
-
-function program1(depth0,data) {
-  
-  var buffer = "";
-  return buffer;
-  }
-
-  buffer += "This template uses custom helpers: "
-    + escapeExpression((helper = helpers['my-helper'] || (depth0 && depth0['my-helper']),options={hash:{},data:data},helper ? helper.call(depth0, "variable", options) : helperMissing.call(depth0, "my-helper", "variable", options)))
+this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(depth0,helpers,partials,data) {
+  return "";
+},"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, helper, options, helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, functionType="function", blockHelperMissing=helpers.blockHelperMissing, buffer = "This template uses custom helpers: "
+    + escapeExpression(((helpers['my-helper'] || (depth0 && depth0['my-helper']) || helperMissing).call(depth0, "variable", {"name":"my-helper","hash":{},"data":data})))
     + " & ";
-  options={hash:{},inverse:self.noop,fn:self.program(1, program1, data),data:data}
-  if (helper = helpers['another-helper']) { stack1 = helper.call(depth0, options); }
-  else { helper = (depth0 && depth0['another-helper']); stack1 = typeof helper === functionType ? helper.call(depth0, options) : helper; }
-  if (!helpers['another-helper']) { stack1 = blockHelperMissing.call(depth0, stack1, {hash:{},inverse:self.noop,fn:self.program(1, program1, data),data:data}); }
-  if(stack1 || stack1 === 0) { buffer += stack1; }
-  buffer += "!\n";
-  return buffer;
-  });
+  stack1 = ((helper = (helper = helpers['another-helper'] || (depth0 != null ? depth0['another-helper'] : depth0)) != null ? helper : helperMissing),(options={"name":"another-helper","hash":{},"fn":this.program(1, data),"inverse":this.noop,"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
+  if (!helpers['another-helper']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "!\n";
+},"useData":true});


### PR DESCRIPTION
Small update to use handlebars 2.0, the existing version based on 1.3 does not work with handlebars 2.0.
