### PR TITLE
Added options.amd as a function

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -205,6 +205,15 @@ module.exports = function(grunt) {
           'tmp/amd_namespace_as_function.js' : ['test/fixtures/modules/**/*.hbs']
         }
       },
+      amd_compile_function: {
+        options: {
+          amd: function() { return ['handlebars', 'custom dependency'].join("', '"); },
+          namespace: false
+        },
+        files: {
+          'tmp/amd_compile_function.js': ['test/fixtures/amd.html']
+        }
+      },
       commonjs_compile: {
         options: {
           commonjs: true

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Enable the compiled file to be required on node.js by preppending and appending 
 For this option to work you need to define the `namespace` option.
 
 #### amd
-Type: `Boolean` or `String` or `Array`
+Type: `Boolean` or `String` or `Array` or `Function`
 Default: `false`
 
 Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
@@ -92,6 +92,8 @@ Wraps the output file with an AMD define function and returns the compiled templ
 If `String` then that string will be used in the module definition `define(['your_amd_opt_here'])`
 
 If `Array` then those strings will be used in the module definition.  `'handlebars'` should always be the first item in the array, eg: `amd: ['handlebars', 'handlebars.helpers']`
+
+If `Function` then it will be called per each module and returned string will be used in the module defintion `"define(['" + options.amd(filename, ast, compiled) + "']"`
 
 ```js
 define(['handlebars'], function(Handlebars) {

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -55,7 +55,7 @@ Enable the compiled file to be required on node.js by preppending and appending 
 For this option to work you need to define the `namespace` option.
 
 ## amd
-Type: `Boolean` or `String` or `Array`
+Type: `Boolean` or `String` or `Array` or `Function`
 Default: `false`
 
 Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
@@ -63,6 +63,8 @@ Wraps the output file with an AMD define function and returns the compiled templ
 If `String` then that string will be used in the module definition `define(['your_amd_opt_here'])`
 
 If `Array` then those strings will be used in the module definition.  `'handlebars'` should always be the first item in the array, eg: `amd: ['handlebars', 'handlebars.helpers']`
+
+If `Function` then it will be called per each module and returned string will be used in the module defintion `"define(['" + options.amd(filename, ast, compiled) + "']"`
 
 ```js
 define(['handlebars'], function(Handlebars) {

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -87,6 +87,8 @@ module.exports = function(grunt) {
       var declarations = [];
       var partials = [];
       var templates = [];
+      // template identifying parts
+      var ast, compiled, filename;
 
       // Namespace info for current template
       var nsInfo;
@@ -121,7 +123,6 @@ module.exports = function(grunt) {
         var src = processContent(grunt.file.read(filepath), filepath);
 
         var Handlebars = require('handlebars');
-        var ast, compiled, filename;
         try {
           // parse the handlebars template into it's AST
           ast = processAST(Handlebars.parse(src));
@@ -191,6 +192,8 @@ module.exports = function(grunt) {
             output.unshift('define([\'handlebars\'], function(Handlebars) {');
           } else if (typeof options.amd === 'string') {
             output.unshift('define([\'' + options.amd + '\'], function(Handlebars) {');
+          } else if (typeof options.amd === 'function') {
+            output.unshift("define(['" + options.amd(filename, ast, compiled) + "'], function(Handlebars) {");
           } else if (Array.isArray(options.amd)) {
             // convert options.amd to a string of dependencies for require([...])
             var amdString = '';

--- a/test/expected/amd_compile_function.js
+++ b/test/expected/amd_compile_function.js
@@ -1,0 +1,7 @@
+define(['handlebars', 'custom dependency'], function(Handlebars) {
+
+return Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+    return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
+},"useData":true})
+
+});

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -187,6 +187,14 @@ exports.handlebars = {
       test.done();
     });
   },
+  amd_compile_function: function(test) {
+    test.expect(1);
+
+    filesAreEqual('amd_compile_function.js', function(actual, expected) {
+      test.equal(actual, expected, 'should wrap everything with an AMD define block and have a custom module name.');
+      test.done();
+    });
+  },
   commonjs_compile: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Allows greater flexibility for building subtemplates dependencies, current implementation allows only static list on the config. With this change dependency list could be built per template from AST or compiled code.

Thank you.

*CLA's signed*