### PR TITLE
Partials output before namespace declaration

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -72,14 +72,19 @@ module.exports = function(grunt) {
 
       // nsdeclare options when fetching namespace info
       var nsDeclareOptions = { response: 'details', declared: nsDeclarations };
+      var nsDeclarePartialOptions = { response: 'details', declared: _.clone(nsDeclarations) };
 
       // Just get the namespace info for a given template
-      var getNamespaceInfo = _.memoize(function(filepath) {
+      var getNamespaceInfo = _.memoize(function(filepath, partial) {
         if (!useNamespace) {return undefined;}
+        var localNsDeclareOptions = nsDeclareOptions;
+        if (partial) {
+          localNsDeclareOptions = nsDeclarePartialOptions;
+        }
         if (_.isFunction(options.namespace)) {
-          return nsdeclare(options.namespace(filepath), nsDeclareOptions);
+          return nsdeclare(options.namespace(filepath), localNsDeclareOptions);
         } else {
-          return nsdeclare(options.namespace, nsDeclareOptions);
+          return nsdeclare(options.namespace, localNsDeclareOptions);
         }
       });
 
@@ -116,7 +121,7 @@ module.exports = function(grunt) {
         if (partialsPathRegex.test(filepath) && isPartialRegex.test(_.last(filepath.split('/')))) {
           filename = processPartialName(filepath);
           if (options.partialsUseNamespace === true) {
-            nsInfo = getNamespaceInfo(filepath);
+            nsInfo = getNamespaceInfo(filepath, true);
 
             partials.push(nsInfo.declaration);
             partials.push('Handlebars.registerPartial('+JSON.stringify(filename)+', '+nsInfo.namespace+'['+JSON.stringify(filename)+'] = '+compiled+');');

--- a/test/expected/partials_use_namespace.js
+++ b/test/expected/partials_use_namespace.js
@@ -4,7 +4,7 @@ Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.templa
   return "<span>Canada</span>";
   },"useData":true}));
 
-
+this["JST"] = this["JST"] || {};
 
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "


### PR DESCRIPTION
Since the 0.9 update, I have seen an issue where the partials are being output before the namespace, and because I am using the option partialsUseNameSpace: true, when the partials are output:

```
// partials
Handlebars.registerPartial("templates/_partial", this["JST"]["templates/_partial"] = ...

// namespace declaration
this["JST"] = this["JST"] || {};

// templates
```

I am not very familiar with this project so I may not be taking other things into consideration with my change, but see the attached PR, it tracks the nsDeclarations separately between the partials and templates.