### PR TITLE
Fixed base namespace code position and return

### DIFF
--- a/test/expected/handlebarsnowrap.js
+++ b/test/expected/handlebarsnowrap.js
@@ -1,8 +1,8 @@
+this["JST"] = this["JST"] || {};
+
 Handlebars.registerPartial("partial", {"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<span>Canada</span>";
   },"useData":true});
-
-this["JST"] = this["JST"] || {};
 
 this["JST"]["test/fixtures/one.hbs"] = {"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "

--- a/test/expected/partials_path_regex.js
+++ b/test/expected/partials_path_regex.js
@@ -1,8 +1,8 @@
+this["JST"] = this["JST"] || {};
+
 Handlebars.registerPartial("partial", Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<span>Canada</span>";
   },"useData":true}));
-
-this["JST"] = this["JST"] || {};
 
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "


### PR DESCRIPTION
Changes
- always write the base namespace to the top
- for commonjs return the first namespace

My usecase looks like:
```coffee
handlebars: 
	options:
		namespace: ( filename )->
			names = filename.replace(/_src_static\/(.*)(\/\w+\.hbs)/, '$1')
			return names.split('/').join('.')
		processName: ( filePath )->
			return path.basename(filePath, '.hbs')
		partialRegex: /.*/,
		partialsPathRegex: /\/partials\//
		partialsUseNamespace: true
		commonjs: true
```

The result, without my changes would look like:

```js
module.exports = function(Handlebars) {

this["jst"]["partials"] = this["jst"]["partials"] || {};

Handlebars.registerPartial("block", /* reduced */, "useData":true}));

// WRONG: This should be at the top
this["jst"] = this["jst"] || {};

this["jst"]["modules"] = /* reduced */

this["jst"]["utils"] = this["jst"]["utils"] || {};

this["jst"]["utils"]["modules"] = /* reduced */

// WRONG: it should return the basic namespace or only this
return this["jst"]["utils"];

};
```