### PR TITLE
AMD with a namespace function

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -307,6 +307,22 @@ module.exports = function(grunt) {
         files: {
           'tmp/namespace_as_function.js' : ['test/fixtures/modules/**/*.hbs']
         }
+      },
+      amd_namespace_as_function: {
+        options: {
+          amd: true,
+          processName: function(filename) {
+            return filename.replace(/.*\/(\w+)\.hbs/, '$1');
+          },
+          returnNamespace: 'JST',
+          namespace: function(filename) {
+            var names = filename.replace(/.*modules\/(.*)(\/\w+\.hbs)/, '$1');
+            return 'JST.' + names.split('/').join('.');
+          }
+        },
+        files: {
+          'tmp/amd_namespace_as_function.js' : ['test/fixtures/modules/**/*.hbs']
+        }
       }
     },
     // Unit tests.

--- a/test/expected/amd_namespace_as_function.js
+++ b/test/expected/amd_namespace_as_function.js
@@ -1,0 +1,19 @@
+define(['handlebars'], function(Handlebars) {
+
+this["JST"] = this["JST"] || {};
+this["JST"]["countries"] = this["JST"]["countries"] || {};
+
+this["JST"]["countries"]["basic"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  return "Basic template that does nothing.";
+  },"useData":true});
+
+this["JST"]["treeNav"] = this["JST"]["treeNav"] || {};
+this["JST"]["treeNav"]["leaves"] = this["JST"]["treeNav"]["leaves"] || {};
+
+this["JST"]["treeNav"]["leaves"]["basic"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  return "Basic template that does nothing.";
+  },"useData":true});
+
+  return this["JST"];
+
+});

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -278,6 +278,15 @@ exports.handlebars = {
         'namespace should allow function to allow nested namespaces based on file system structure.');
       test.done();
     });
+  },
+  amd_namespace_as_function: function(test) {
+    test.expect(1);
+
+    filesAreEqual('amd_namespace_as_function.js', function(actual, expected) {
+      test.equal(actual, expected,
+        'allow namespace function while using amd option');
+      test.done();
+    });
   }
 
 };


### PR DESCRIPTION
I came across an issue when using `amd: true` and a function for namespaces.

As proved by the failing test, an incorrect namespace is being used in the return statement.
Currently, the namespace for the last file is used. This is fine if there is only a single file, but when trying to compile multiple files this is an issue.

I propose adding a `returnNamespace` option, which allows the user to specify the namespace that should be returned. I feel that trying to "work out" what this should be would add unnecessary complexity.

Old Behaviour:
```
// Gruntfile.js
options: {
  processName: function(filename) {
    return filename.replace(/.*\/(\w+)\.hbs/, '$1');
  },
  namespace: function(filename) {
    var names = filename.replace(/.*modules\/(.*)(\/\w+\.hbs)/, '$1');
    return 'JST.' + names.split('/').join('.');
  }
},

// Output
define(['handlebars'], function(Handlebars) {
...
return this["JST"]["treeNav"]["leaves"];
})
```

New Behaviour:
```
// Gruntfile.js
options: {
  processName: function(filename) {
    return filename.replace(/.*\/(\w+)\.hbs/, '$1');
  },
  returnNamespace: 'JST',
  namespace: function(filename) {
    var names = filename.replace(/.*modules\/(.*)(\/\w+\.hbs)/, '$1');
    return 'JST.' + names.split('/').join('.');
  }
},

// Output
define(['handlebars'], function(Handlebars) {
...
return this["JST"];
})
```