### PR TITLE
Supports handlebarsjs.runtime v3.0.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,9 +107,9 @@ module.exports = function(grunt) {
       process_ast: {
         options: {
           processAST: function(ast) {
-            ast.statements.forEach(function(statement, i) {
-              if (statement.type === 'partial') {
-                ast.statements[i] = {type: 'content', string: 'Fooville'};
+            ast.body.forEach(function(statement, i) {
+              if (statement.type === 'PartialStatement') {
+                ast.body[i] = {type: 'ContentStatement', value: 'Fooville'};
               }
             });
             return ast;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 
 ## Getting Started
-This plugin requires Grunt `~0.4.0`
+This plugin requires Grunt `>=0.4.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -281,4 +281,4 @@ handlebars: {
 
 Task submitted by [Tim Branyen](http://tbranyen.com)
 
-*This file was generated on Wed Feb 04 2015 21:57:25.*
+*This file was generated on Wed Feb 11 2015 00:39:41.*

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "chalk": "^0.5.1",
-    "handlebars": "^2.0.0",
+    "handlebars": "^3.0.0",
     "nsdeclare": "0.1.0"
   },
   "devDependencies": {

--- a/test/expected/amd_partials_no_namespace.js
+++ b/test/expected/amd_partials_no_namespace.js
@@ -3,16 +3,17 @@ define(['handlebars'], function(Handlebars) {
 this["JST"] = this["JST"] || {};
 
 Handlebars.registerPartial("partial", Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  return "<span>Canada</span>";
-  },"useData":true}));
+    return "<span>Canada</span>";
+},"useData":true}));
 
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
-    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
-    + ". I live in ";
-  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</p>";
+    var stack1, helper;
+
+  return "<p>Hello, my name is "
+    + this.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0,{"name":"name","hash":{},"data":data}) : helper)))
+    + ". I live in "
+    + ((stack1 = this.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials})) != null ? stack1 : "")
+    + "</p>";
 },"usePartial":true,"useData":true});
 
 return this["JST"];

--- a/test/expected/amd_partials_use_namespace.js
+++ b/test/expected/amd_partials_use_namespace.js
@@ -3,18 +3,17 @@ define(['handlebars'], function(Handlebars) {
 this["JST"] = this["JST"] || {};
 
 Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  return "<span>Canada</span>";
-  },"useData":true}));
-
-
+    return "<span>Canada</span>";
+},"useData":true}));
 
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
-    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
-    + ". I live in ";
-  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</p>";
+    var stack1, helper;
+
+  return "<p>Hello, my name is "
+    + this.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0,{"name":"name","hash":{},"data":data}) : helper)))
+    + ". I live in "
+    + ((stack1 = this.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials})) != null ? stack1 : "")
+    + "</p>";
 },"usePartial":true,"useData":true});
 
 return this["JST"];

--- a/test/expected/handlebarsnowrap.js
+++ b/test/expected/handlebarsnowrap.js
@@ -5,10 +5,11 @@ Handlebars.registerPartial("partial", {"compiler":[6,">= 2.0.0-beta.1"],"main":f
   },"useData":true});
 
 this["JST"]["test/fixtures/one.hbs"] = {"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
-    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
-    + ". I live in ";
-  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</p>";
+    var stack1, helper;
+  
+  return "<p>Hello, my name is "
+    + this.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
+    + ". I live in "
+    + ((stack1 = this.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials})) != null ? stack1 : "")
+    + "</p>";
 },"usePartial":true,"useData":true};

--- a/test/expected/known_helpers.js
+++ b/test/expected/known_helpers.js
@@ -1,13 +1,14 @@
 this["JST"] = this["JST"] || {};
 
 this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(depth0,helpers,partials,data) {
-  return "";
+    return "";
 },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, options, escapeExpression=this.escapeExpression, functionType="function", helperMissing=helpers.helperMissing, blockHelperMissing=helpers.blockHelperMissing, buffer = "This template uses custom helpers: "
-    + escapeExpression(helpers['my-helper'].call(depth0, "variable", {"name":"my-helper","hash":{},"data":data}))
+    var stack1, helper, options, buffer = 
+  "This template uses custom helpers: "
+    + this.escapeExpression(helpers['my-helper'].call(depth0,"variable",{"name":"my-helper","hash":{},"data":data}))
     + " & ";
-  stack1 = ((helper = (helper = helpers['another-helper'] || (depth0 != null ? depth0['another-helper'] : depth0)) != null ? helper : helperMissing),(options={"name":"another-helper","hash":{},"fn":this.program(1, data),"inverse":this.noop,"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
-  if (!helpers['another-helper']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+  stack1 = ((helper = (helper = helpers['another-helper'] || (depth0 != null ? depth0['another-helper'] : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"another-helper","hash":{},"fn":this.program(1, data, 0),"inverse":this.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0,options) : helper));
+  if (!helpers['another-helper']) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "!\n";
 },"useData":true});

--- a/test/expected/only_known_helpers.js
+++ b/test/expected/only_known_helpers.js
@@ -1,12 +1,13 @@
 this["JST"] = this["JST"] || {};
 
 this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(depth0,helpers,partials,data) {
-  return "";
+    return "";
 },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, escapeExpression=this.escapeExpression, buffer = "This template uses custom helpers: "
-    + escapeExpression(helpers['my-helper'].call(depth0, "variable", {"name":"my-helper","hash":{},"data":data}))
-    + " & ";
-  stack1 = helpers['another-helper'].call(depth0, {"name":"another-helper","hash":{},"fn":this.program(1, data),"inverse":this.noop,"data":data});
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "!\n";
+    var stack1;
+
+  return "This template uses custom helpers: "
+    + this.escapeExpression(helpers['my-helper'].call(depth0,"variable",{"name":"my-helper","hash":{},"data":data}))
+    + " & "
+    + ((stack1 = helpers['another-helper'].call(depth0,{"name":"another-helper","hash":{},"fn":this.program(1, data, 0),"inverse":this.noop,"data":data})) != null ? stack1 : "")
+    + "!\n";
 },"useData":true});

--- a/test/expected/partials_path_regex.js
+++ b/test/expected/partials_path_regex.js
@@ -1,14 +1,15 @@
 this["JST"] = this["JST"] || {};
 
 Handlebars.registerPartial("partial", Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  return "<span>Canada</span>";
-  },"useData":true}));
+    return "<span>Canada</span>";
+},"useData":true}));
 
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
-    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
-    + ". I live in ";
-  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</p>";
+    var stack1, helper;
+
+  return "<p>Hello, my name is "
+    + this.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0,{"name":"name","hash":{},"data":data}) : helper)))
+    + ". I live in "
+    + ((stack1 = this.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials})) != null ? stack1 : "")
+    + "</p>";
 },"usePartial":true,"useData":true});

--- a/test/expected/partials_use_namespace.js
+++ b/test/expected/partials_use_namespace.js
@@ -1,16 +1,15 @@
 this["JST"] = this["JST"] || {};
 
 Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  return "<span>Canada</span>";
-  },"useData":true}));
-
-
+    return "<span>Canada</span>";
+},"useData":true}));
 
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
-    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
-    + ". I live in ";
-  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</p>";
+    var stack1, helper;
+
+  return "<p>Hello, my name is "
+    + this.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0,{"name":"name","hash":{},"data":data}) : helper)))
+    + ". I live in "
+    + ((stack1 = this.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials})) != null ? stack1 : "")
+    + "</p>";
 },"usePartial":true,"useData":true});

--- a/test/expected/partials_use_namespace_multiple_templates.js
+++ b/test/expected/partials_use_namespace_multiple_templates.js
@@ -1,18 +1,19 @@
 this["JST"] = this["JST"] || {};
 
 Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  return "<span>Canada</span>";
-  },"useData":true}));
+    return "<span>Canada</span>";
+},"useData":true}));
 
 this["JST"]["test/fixtures/has-spaces.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  return "\n\n    <div>\n        <span>this template has many spaces</span>\n    </div>\n";
-  },"useData":true});
+    return "\n\n    <div>\n        <span>this template has many spaces</span>\n    </div>\n";
+},"useData":true});
 
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<p>Hello, my name is "
-    + escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"name","hash":{},"data":data}) : helper)))
-    + ". I live in ";
-  stack1 = this.invokePartial(partials.partial, '', 'partial', depth0, undefined, helpers, partials, data);
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</p>";
+    var stack1, helper;
+
+  return "<p>Hello, my name is "
+    + this.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0,{"name":"name","hash":{},"data":data}) : helper)))
+    + ". I live in "
+    + ((stack1 = this.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials})) != null ? stack1 : "")
+    + "</p>";
 },"usePartial":true,"useData":true});

--- a/test/expected/process_ast.js
+++ b/test/expected/process_ast.js
@@ -1,15 +1,11 @@
 this["JST"] = this["JST"] || {};
 
-this["JST"]["test/fixtures/one.hbs"] = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
-  this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
-  var buffer = "", stack1, functionType="function", escapeExpression=this.escapeExpression;
+this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+    var stack1, helper;
 
-
-  buffer += "<p>Hello, my name is ";
-  if (stack1 = helpers.name) { stack1 = stack1.call(depth0, {hash:{},data:data}); }
-  else { stack1 = (depth0 && depth0.name); stack1 = typeof stack1 === functionType ? stack1.call(depth0, {hash:{},data:data}) : stack1; }
-  buffer += escapeExpression(stack1)
-    + ". I live in Fooville</p>";
-  return buffer;
-  });
+  return "<p>Hello, my name is "
+    + this.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0,{"name":"name","hash":{},"data":data}) : helper)))
+    + ". I live in "
+    + ((stack1 = this.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials})) != null ? stack1 : "")
+    + "</p>";
+},"usePartial":true,"useData":true});

--- a/test/expected/unknown_helpers.js
+++ b/test/expected/unknown_helpers.js
@@ -1,13 +1,14 @@
 this["JST"] = this["JST"] || {};
 
 this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(depth0,helpers,partials,data) {
-  return "";
+    return "";
 },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
-  var stack1, helper, options, helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, functionType="function", blockHelperMissing=helpers.blockHelperMissing, buffer = "This template uses custom helpers: "
-    + escapeExpression(((helpers['my-helper'] || (depth0 && depth0['my-helper']) || helperMissing).call(depth0, "variable", {"name":"my-helper","hash":{},"data":data})))
+    var stack1, helper, options, alias1=helpers.helperMissing, buffer = 
+  "This template uses custom helpers: "
+    + this.escapeExpression((helpers['my-helper'] || (depth0 && depth0['my-helper']) || alias1).call(depth0,"variable",{"name":"my-helper","hash":{},"data":data}))
     + " & ";
-  stack1 = ((helper = (helper = helpers['another-helper'] || (depth0 != null ? depth0['another-helper'] : depth0)) != null ? helper : helperMissing),(options={"name":"another-helper","hash":{},"fn":this.program(1, data),"inverse":this.noop,"data":data}),(typeof helper === functionType ? helper.call(depth0, options) : helper));
-  if (!helpers['another-helper']) { stack1 = blockHelperMissing.call(depth0, stack1, options); }
+  stack1 = ((helper = (helper = helpers['another-helper'] || (depth0 != null ? depth0['another-helper'] : depth0)) != null ? helper : alias1),(options={"name":"another-helper","hash":{},"fn":this.program(1, data, 0),"inverse":this.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0,options) : helper));
+  if (!helpers['another-helper']) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "!\n";
 },"useData":true});

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -256,7 +256,7 @@ exports.handlebars = {
       test.done();
     });
   },
-  partials_path: function(test) {
+  partials_path_regex: function(test) {
     test.expect(1);
 
     filesAreEqual('partials_path_regex.js', function(actual, expected) {


### PR DESCRIPTION
In Handlebars.runtime above 3.0.0, It has changed some arguments and output formats related test cases.

For example, `invokePartial` uses three arguments unlike in the past.
https://github.com/wycats/handlebars.js/commit/f990cf006422fbcbbae7d8a8a866831e58300ea4