### PR TITLE
Return compiled template directly for commonjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 node_modules
 npm-debug.log
 tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.swp
 node_modules
 npm-debug.log
 tmp

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -10,7 +10,7 @@ Concatenated files will be joined on this string.
 Type: `String` or `false` or `function`
 Default: `'JST'`
 
-The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces or false for no namespace wrapping.*  When false with `amd` option set `true`, templates will be returned directly from the AMD wrapper.
+The namespace in which the precompiled templates will be assigned.  *Use dot notation (e.g. App.Templates) for nested namespaces or false for no namespace wrapping.*  When false with `amd` or `commonjs` option set `true`, templates will be returned directly from the AMD/CommonJS wrapper.
 
 Example:
 ```js

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -150,7 +150,7 @@ module.exports = function(grunt) {
             partials.push('Handlebars.registerPartial(' + JSON.stringify(filename) + ', ' + compiled + ');');
           }
         } else {
-          if (options.amd && !useNamespace) {
+          if ((options.amd || options.commonjs) && !useNamespace) {
             compiled = 'return ' + compiled;
           }
           filename = processName(filepath);
@@ -161,7 +161,7 @@ module.exports = function(grunt) {
             }
             templates.push(nsInfo.namespace + '[' + JSON.stringify(filename) + '] = ' + compiled + ';');
           } else if (options.commonjs === true) {
-            templates.push('templates[' + JSON.stringify(filename) + '] = ' + compiled + ';');
+            templates.push(compiled + ';');
           } else {
             templates.push(compiled);
           }
@@ -217,9 +217,6 @@ module.exports = function(grunt) {
         if (options.commonjs) {
           if (useNamespace) {
             output.push('return ' + nsInfo.namespace + ';');
-          } else {
-            output.unshift('var templates = {};');
-            output.push('return templates;');
           }
           // Export the templates object for CommonJS environments.
           output.unshift('module.exports = function(Handlebars) {');

--- a/test/expected/commonjs_compile_direct.js
+++ b/test/expected/commonjs_compile_direct.js
@@ -1,11 +1,7 @@
 module.exports = function(Handlebars) {
 
-var templates = {};
-
-templates["test/fixtures/commonjs.html"] = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+return Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with CommonJS support</p>\n</section>\n";
   },"useData":true});
-
-return templates;
 
 };


### PR DESCRIPTION
Fixes #86
When namespace = false and commonjs = true, return the compiled template
directly.
Based on changes by @janpanschab.