### PR TITLE
Add return statement to partials for AMD, issue #76

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -190,6 +190,15 @@ module.exports = function(grunt) {
           'tmp/amd_partials_no_namespace.js': ['test/fixtures/_partial.hbs', 'test/fixtures/one.hbs']
         }
       },
+      amd_partials_no_namespace_single_input: {
+        options: {
+          amd: ['handlebars'],
+          partialsUseNamespace: false
+        },
+        files: {
+          'tmp/amd_partials_no_namespace_single_input.js': ['test/fixtures/_partial.hbs']
+        }
+      },
       amd_namespace_as_function: {
         options: {
           amd: ['handlebars', 'handlebars.helpers'],

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -58,7 +58,7 @@ For this option to work you need to define the `namespace` option.
 Type: `Boolean` or `String` or `Array` or `Function`
 Default: `false`
 
-Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
+Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly. Partial templates will be returned directly if they are the only input to the file.
 
 If `String` then that string will be used in the module definition `define(['your_amd_opt_here'])`
 

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -147,7 +147,15 @@ module.exports = function(grunt) {
             partials.push('Handlebars.registerPartial(' + JSON.stringify(filename) + ', ' + nsInfo.namespace +
               '[' + JSON.stringify(filename) + '] = ' + compiled + ');');
           } else {
-            partials.push('Handlebars.registerPartial(' + JSON.stringify(filename) + ', ' + compiled + ');');
+            if ((options.amd || options.commonjs) && f.src.length === 1) {
+              partials.push(
+                'var compiledPartial = ' + compiled + ';\n' +
+                'Handlebars.registerPartial(' + JSON.stringify(filename) + ', compiledPartial);\n' +
+                'return compiledPartial;'
+              );
+            } else {
+              partials.push('Handlebars.registerPartial(' + JSON.stringify(filename) + ', ' + compiled + ');');
+            }
           }
         } else {
           if ((options.amd || options.commonjs) && !useNamespace) {
@@ -208,7 +216,7 @@ module.exports = function(grunt) {
             output.unshift('define([' + amdString + '], function(Handlebars) {');
           }
 
-          if (useNamespace) {
+          if (useNamespace && templates.length) {
             // Namespace has not been explicitly set to false; the AMD
             // wrapper will return the object containing the template.
             output.push('return ' + extractGlobalNamespace(nsDeclarations) + ';');

--- a/test/expected/amd_partials_no_namespace_single_input.js
+++ b/test/expected/amd_partials_no_namespace_single_input.js
@@ -1,0 +1,9 @@
+define(['handlebars'], function(Handlebars) {
+
+var compiledPartial = Handlebars.template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+	return "<span>Canada</span>";
+},"useData":true});
+Handlebars.registerPartial("partial", compiledPartial);
+return compiledPartial;
+
+});

--- a/test/handlebars_test.js
+++ b/test/handlebars_test.js
@@ -178,6 +178,15 @@ exports.handlebars = {
       test.done();
     });
   },
+  amd_partials_no_namespace_single_input: function(test) {
+    test.expect(1);
+
+    filesAreEqual('amd_partials_no_namespace_single_input.js', function(actual, expected) {
+      test.equal(actual, expected, 'should wrap partial with an AMD define block and no namespace and ' +
+        'return the partial template when the partial is the only input file.');
+      test.done();
+    });
+  },
   amd_namespace_as_function: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Makes the compiler return templates for partials to amd module definitions if the partial is the only input file to the compiled file and namespace is not used. Fixes #76 