### PR TITLE
Handlebarsjs library version upgrade to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "handlebars": "^3.0.0",
+    "handlebars": "^4.0.0",
     "chalk": "^1.0.0",
     "nsdeclare": "0.1.0"
   },


### PR DESCRIPTION
Changed handlebars version to 4.0.0 in package.json because of a frontend error in the latest handlebarsjs web library. "Uncaught Error: Template was precompiled with an older version of Handlebars than the current runtime. Please update your precompiler to a newer version (>= 4.0.0) or downgrade your runtime to an older version (>= 2.0.0-beta.1)."