### PR TITLE
Add a 'disableGlobal' option

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -97,6 +97,11 @@ module.exports = function(grunt) {
 
       // nsdeclare options when fetching namespace info
       var nsDeclareOptions = {response: 'details', declared: nsDeclarations};
+      
+      // if 'disableGlobal' option is true prevent the templates to be declared in the global namespace
+      if (options.disableGlobal) {
+          nsDeclareOptions.root = "templates";
+      }
 
       // Just get the namespace info for a given template
       var getNamespaceInfo = _.memoize(function(filepath) {
@@ -184,6 +189,11 @@ module.exports = function(grunt) {
           }
 
         }
+        
+        // if the 'disableGlobal' option is true create a local root variable to contain the templates
+        if (options.disableGlobal) {
+            output.unshift('var ' + nsDeclareOptions.root + ' = {};');
+        } 
 
         if (options.amd) {
           // Wrap the file in an AMD define fn.

--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -97,10 +97,10 @@ module.exports = function(grunt) {
 
       // nsdeclare options when fetching namespace info
       var nsDeclareOptions = {response: 'details', declared: nsDeclarations};
-      
+
       // if 'disableGlobal' option is true prevent the templates to be declared in the global namespace
       if (options.disableGlobal) {
-          nsDeclareOptions.root = "templates";
+        nsDeclareOptions.root = 'templates';
       }
 
       // Just get the namespace info for a given template
@@ -187,13 +187,12 @@ module.exports = function(grunt) {
 
             output.push(nodeExport);
           }
-
         }
-        
+
         // if the 'disableGlobal' option is true create a local root variable to contain the templates
         if (options.disableGlobal) {
-            output.unshift('var ' + nsDeclareOptions.root + ' = {};');
-        } 
+          output.unshift('var ' + nsDeclareOptions.root + ' = {};');
+        }
 
         if (options.amd) {
           // Wrap the file in an AMD define fn.


### PR DESCRIPTION
I had some problems loading the templates using grunt-babelify. It was trying to add the modules in a global namespace using the "this" object. I added this option to keep the templates out of the global namespace and only return them with the exported function.