### PR TITLE
Address gruntjs/grunt-contrib-handlebars#154 and update node modules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+v2.0.0:
+  date: 2019-01-01
+  changes:
+    - Updated outdated NPM dependencies
+    - Fixed failing tests
+    - Changed node engine from 0.10.0 to 11.6.0
+    - Updated how options.amd works when it is supplied as a function
+      - Documentation Update for options.amd
 v1.0.0:
   date: 2016-03-04
   changes:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -205,13 +205,31 @@ module.exports = function(grunt) {
           'tmp/amd_namespace_as_function.js': ['test/fixtures/modules/**/*.hbs']
         }
       },
-      amd_compile_function: {
+      amd_compile_function_return_string: {
         options: {
           amd: function() { return ['handlebars', 'custom dependency'].join("', '"); },
           namespace: false
         },
         files: {
-          'tmp/amd_compile_function.js': ['test/fixtures/amd.html']
+          'tmp/amd_compile_function_return_string.js': ['test/fixtures/amd.html']
+        }
+      },
+      amd_compile_function_return_boolean: {
+        options: {
+          amd: function() { return true; },
+          namespace: false
+        },
+        files: {
+          'tmp/amd_compile_function_return_boolean.js': ['test/fixtures/amd.html']
+        }
+      },
+      amd_compile_function_return_array: {
+        options: {
+          amd: function() { return ['handlebars', 'custom dependency']; },
+          namespace: false
+        },
+        files: {
+          'tmp/amd_compile_function_return_array.js': ['test/fixtures/amd.html']
         }
       },
       commonjs_compile: {

--- a/docs/handlebars-options.md
+++ b/docs/handlebars-options.md
@@ -1,13 +1,13 @@
 # Options
 
 ## separator
-Type: `String`  
+Type: `String`
 Default: `linefeed + linefeed`
 
 Concatenated files will be joined on this string.
 
 ## namespace
-Type: `String` or `false` or `function`  
+Type: `String` or `false` or `function`
 Default: `'JST'`
 
 The namespace in which the precompiled templates will be assigned. *Use dot notation (e.g. App.Templates) for nested namespaces or false for no namespace wrapping.* When false with `amd` or `commonjs` option set `true`, templates will be returned directly from the AMD/CommonJS wrapper.
@@ -35,19 +35,19 @@ files: {
 ```
 
 ## partialsUseNamespace
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 When set to `true`, partials will be registered in the `namespace` in addition to templates.
 
 ## wrapped
-Type: `Boolean`  
+Type: `Boolean`
 Default: `true`
 
 Determine if preprocessed template functions will be wrapped in Handlebars.template function.
 
 ## node
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 Enable the compiled file to be required on node.js by preppending and appending proper declarations. You can use the file safely on the front-end.
@@ -55,7 +55,7 @@ Enable the compiled file to be required on node.js by preppending and appending 
 For this option to work you need to define the `namespace` option.
 
 ## amd
-Type: `Boolean` or `String` or `Array` or `Function`  
+Type: `Boolean` or `String` or `Array` or `Function`
 Default: `false`
 
 Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
@@ -64,8 +64,49 @@ If `String` then that string will be used in the module definition `define(['you
 
 If `Array` then those strings will be used in the module definition. `'handlebars'` should always be the first item in the array, eg: `amd: ['handlebars', 'handlebars.helpers']`
 
-If `Function` then it will be called per each module and returned string will be used in the module defintion `"define(['" + options.amd(filename, ast, compiled) + "']"`
+If `Function` then it will be called per each module and returned string/array/boolean will be used in the module defintion `"define(['" + options.amd(filename, ast, compiled) + "']"`
 
+If a string is returned from the function it will make it the modules tobe included
+```js
+  //...//
+  "amd" : function() {
+    reutrn '\'handlebars\', \'another module\'';
+  }
+  //...//
+```
+Output:
+```js
+define(['handlebars', 'another module'], function(Handlebars) {
+    //...//
+    return this['[template namespace]'];
+});
+```
+
+If an array is returned from the function it will wrap the values in qoutes and join it into the modules tobe included
+```js
+  //...//
+  "amd" : function() {
+    reutrn ['handlebars', 'another module'];
+  }
+  //...//
+```
+Output:
+```js
+define(['handlebars', 'another module']], function(Handlebars) {
+    //...//
+    return this['[template namespace]'];
+});
+```
+
+If a boolean is returned from the function it will treated as if it was included in the grunt config options
+```js
+  //...//
+  "amd" : function() {
+    reutrn true;
+  }
+  //...//
+```
+Output:
 ```js
 define(['handlebars'], function(Handlebars) {
     //...//
@@ -74,7 +115,7 @@ define(['handlebars'], function(Handlebars) {
 ```
 
 ## commonjs
-Type: `Boolean`  
+Type: `Boolean`
 Default: `false`
 
 Wraps the output file in a CommonJS module function, exporting the compiled templates. It will also add templates to the template namespace, unless `namespace` is explicitly set to `false`.
@@ -157,7 +198,7 @@ options: {
 Note: If processPartialName is not provided as an option the default assumes that partials will be stored by stripping trailing underscore characters and filename extensions. For example, the path *templates/_header.hbs* will become *header* and can be referenced in other templates as *{{> header}}*.
 
 ## partialRegex
-Type: `Regexp`  
+Type: `Regexp`
 Default: `/^_/`
 
 This option accepts a regex that defines the prefix character that is used to identify Handlebars partial files.
@@ -170,7 +211,7 @@ options: {
 ```
 
 ## partialsPathRegex
-Type: `Regexp`  
+Type: `Regexp`
 Default: `/./`
 
 This option accepts a regex that defines the path to a directory of Handlebars partials files. The example below shows how to mark every file in a specific directory as a partial.
@@ -183,7 +224,7 @@ options: {
 ```
 
 ## compilerOptions
-Type `Object`  
+Type `Object`
 Default: `{}`
 
 This option allows you to specify a hash of options which will be passed directly to the Handlebars compiler.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-contrib-handlebars",
   "description": "Precompile Handlebars templates to JST file.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
@@ -9,7 +9,7 @@
   "repository": "gruntjs/grunt-contrib-handlebars",
   "license": "MIT",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=11.6.0"
   },
   "main": "tasks/handlebars.js",
   "scripts": {
@@ -17,16 +17,16 @@
   },
   "dependencies": {
     "handlebars": "~4.0.0",
-    "chalk": "^1.0.0",
+    "chalk": "^2.4.1",
     "nsdeclare": "0.1.0"
   },
   "devDependencies": {
     "grunt": "^1.0.0",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-internal": "^1.1.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-nodeunit": "^1.0.0",
-    "grunt-jscs": "^2.1.0"
+    "grunt-contrib-clean": "^2.0.0",
+    "grunt-contrib-internal": "^3.1.0",
+    "grunt-contrib-jshint": "^2.0.0",
+    "grunt-contrib-nodeunit": "^2.0.0",
+    "grunt-jscs": "^3.0.1"
   },
   "keywords": [
     "gruntplugin"

--- a/test/expected/amd_compile_function_return_array.js
+++ b/test/expected/amd_compile_function_return_array.js
@@ -1,0 +1,7 @@
+define(['handlebars', 'custom dependency'], function(Handlebars) {
+
+return Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
+},"useData":true})
+
+});

--- a/test/expected/amd_compile_function_return_boolean.js
+++ b/test/expected/amd_compile_function_return_boolean.js
@@ -1,0 +1,7 @@
+define(['handlebars'], function(Handlebars) {
+
+return Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
+},"useData":true})
+
+});

--- a/test/expected/amd_compile_function_return_string.js
+++ b/test/expected/amd_compile_function_return_string.js
@@ -1,0 +1,7 @@
+define(['handlebars', 'custom dependency'], function(Handlebars) {
+
+return Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    return "<section class=\"main-app\">\n    <h1>Some title</h1>\n    <p>I've been compiled with amd support</p>\n</section>";
+},"useData":true})
+
+});

--- a/test/expected/amd_partials_no_namespace.js
+++ b/test/expected/amd_partials_no_namespace.js
@@ -9,8 +9,8 @@ Handlebars.registerPartial("partial", Handlebars.template({"compiler":[7,">= 4.0
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
-  return "<p>Hello, my name is "
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"name","hash":{},"data":data}) : helper)))
+    return "<p>Hello, my name is "
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in "
     + ((stack1 = container.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</p>";

--- a/test/expected/amd_partials_use_namespace.js
+++ b/test/expected/amd_partials_use_namespace.js
@@ -9,8 +9,8 @@ Handlebars.registerPartial("partial", this["JST"]["partial"] = Handlebars.templa
 this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
-  return "<p>Hello, my name is "
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"name","hash":{},"data":data}) : helper)))
+    return "<p>Hello, my name is "
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in "
     + ((stack1 = container.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</p>";

--- a/test/expected/handlebarsnowrap.js
+++ b/test/expected/handlebarsnowrap.js
@@ -8,7 +8,7 @@ this["JST"]["test/fixtures/one.hbs"] = {"compiler":[7,">= 4.0.0"],"main":functio
     var stack1, helper;
 
   return "<p>Hello, my name is "
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"name","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in "
     + ((stack1 = container.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</p>";

--- a/test/expected/known_helpers.js
+++ b/test/expected/known_helpers.js
@@ -3,7 +3,7 @@ this["JST"] = this["JST"] || {};
 this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(container,depth0,helpers,partials,data) {
     return "";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, alias1=depth0 != null ? depth0 : {}, buffer = 
+    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), buffer = 
   "This template uses custom helpers: "
     + container.escapeExpression(helpers["my-helper"].call(alias1,"variable",{"name":"my-helper","hash":{},"data":data}))
     + " & ";

--- a/test/expected/only_known_helpers.js
+++ b/test/expected/only_known_helpers.js
@@ -3,7 +3,7 @@ this["JST"] = this["JST"] || {};
 this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(container,depth0,helpers,partials,data) {
     return "";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    var stack1, alias1=depth0 != null ? depth0 : {};
+    var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "This template uses custom helpers: "
     + container.escapeExpression(helpers["my-helper"].call(alias1,"variable",{"name":"my-helper","hash":{},"data":data}))

--- a/test/expected/partials_path_regex.js
+++ b/test/expected/partials_path_regex.js
@@ -8,7 +8,7 @@ this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[7,">= 4.
     var stack1, helper;
 
   return "<p>Hello, my name is "
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"name","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in "
     + ((stack1 = container.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</p>";

--- a/test/expected/partials_use_namespace.js
+++ b/test/expected/partials_use_namespace.js
@@ -8,7 +8,7 @@ this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[7,">= 4.
     var stack1, helper;
 
   return "<p>Hello, my name is "
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"name","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in "
     + ((stack1 = container.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</p>";

--- a/test/expected/partials_use_namespace_multiple_templates.js
+++ b/test/expected/partials_use_namespace_multiple_templates.js
@@ -12,7 +12,7 @@ this["JST"]["test/fixtures/one.hbs"] = Handlebars.template({"compiler":[7,">= 4.
     var stack1, helper;
 
   return "<p>Hello, my name is "
-    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"name","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"name","hash":{},"data":data}) : helper)))
     + ". I live in "
     + ((stack1 = container.invokePartial(partials.partial,depth0,{"name":"partial","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</p>";

--- a/test/expected/unknown_helpers.js
+++ b/test/expected/unknown_helpers.js
@@ -3,7 +3,7 @@ this["JST"] = this["JST"] || {};
 this["JST"]["test/fixtures/uses_helpers.hbs"] = Handlebars.template({"1":function(container,depth0,helpers,partials,data) {
     return "";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, buffer = 
+    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, buffer = 
   "This template uses custom helpers: "
     + container.escapeExpression((helpers["my-helper"] || (depth0 && depth0["my-helper"]) || alias2).call(alias1,"variable",{"name":"my-helper","hash":{},"data":data}))
     + " & ";


### PR DESCRIPTION
Squashed commit of the following:

commit 6e51bb885e202c237a14bc71910e80bee47eb50e
Author: rcampbel <1334061+rcampbel@users.noreply.github.com>
Date:   Tue Jan 1 04:05:13 2019 -0500

    Updated documentation and changelog

commit 4671b63b32e0a53f6eff4b19f83251ebfa2bbb3d
Author: rcampbel <1334061+rcampbel@users.noreply.github.com>
Date:   Tue Jan 1 04:04:57 2019 -0500

    Encapsulated the logic for processing the AMD content out into it’s own function;  Updated the check for AMD  when seeing if `return` needs to be prepended to the compiled template if a namespace is not being used;

commit babafab72cedfe830a8afde42f4d592e78dfaffe
Author: rcampbel <1334061+rcampbel@users.noreply.github.com>
Date:   Tue Jan 1 04:04:41 2019 -0500

    Added failing tests

commit 33afc8af957ed262561eda03ed727bcee91dad14
Author: rcampbel <1334061+rcampbel@users.noreply.github.com>
Date:   Tue Jan 1 04:04:27 2019 -0500

    Updating node modules, node version dependency, and package version

commit 5a3fd2f802a5daa9dd7564f40f8d9de12bd53953
Author: rcampbel <1334061+rcampbel@users.noreply.github.com>
Date:   Tue Jan 1 04:04:00 2019 -0500

    Updated unit tests to pass prior to making any other change